### PR TITLE
Add horizontal text alignment, centered

### DIFF
--- a/appinfo.json
+++ b/appinfo.json
@@ -11,6 +11,9 @@
     },
     "sdkVersion": "3",
     "shortName": "hello",
+    "targetPlatforms": [
+        "aplite"
+    ],
     "uuid": "54e21335-f74c-44aa-85da-4f11ef14938a",
     "versionLabel": "1.0",
     "watchapp": {

--- a/src/Hellopebble.c
+++ b/src/Hellopebble.c
@@ -7,6 +7,13 @@ void init() {
    window = window_create();
    text_layer = text_layer_create(GRect(0, 0, 144, 40));
    text_layer_set_text(text_layer, "Pebble");
+   // horizontal alignment
+   // See https://developer.getpebble.com/docs/c/User_Interface/Layers/TextLayer/#text_layer_set_text_alignment
+   text_layer_set_text_alignment(text_layer, GTextAlignmentCenter);
+   // vertical alignment
+   // See https://forums.getpebble.com/discussion/12492/vertical-text-alignment
+   // not implemented yet
+  
    layer_add_child(window_get_root_layer(window),
                    text_layer_get_layer(text_layer));
    window_stack_push(window, true);


### PR DESCRIPTION
Isaac, I figured out how to center-align the text horizontally. You have to use the `text_layer_set_text_alignment()` function, which is documented [here](https://developer.getpebble.com/docs/c/User_Interface/Layers/TextLayer/#text_layer_set_text_alignment). Notice that it takes two arguments. The first argument is a text_layer. We have conveniently named our text_layer "text_layer". The second argument is a text_alignment, which must be one of the three types listed [here](https://developer.getpebble.com/docs/c/Graphics/Drawing_Text/#GTextAlignment). 

But centering text vertically is more complex. I also put in a comment with a URL for how to do that. But I didn't add any code for that yet. 
